### PR TITLE
Allow URL pointing to "invalid" domains.

### DIFF
--- a/web-app/tgol-web-app/src/main/java/org/tanaguru/webapp/validator/CreateContractFormValidator.java
+++ b/web-app/tgol-web-app/src/main/java/org/tanaguru/webapp/validator/CreateContractFormValidator.java
@@ -25,6 +25,7 @@ import java.util.*;
 import java.util.Map.Entry;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.validator.routines.RegexValidator;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.tanaguru.webapp.command.CreateContractCommand;
 import org.tanaguru.webapp.entity.user.User;
@@ -229,7 +230,7 @@ public class CreateContractFormValidator implements Validator {
             return true;
         }
         String[] schemes = {"http","https"};
-        UrlValidator urlValidator = new UrlValidator (schemes, UrlValidator.ALLOW_2_SLASHES);
+        UrlValidator urlValidator = new UrlValidator (schemes, new RegexValidator("^.*$"), UrlValidator.ALLOW_2_SLASHES);
         if (!urlValidator.isValid(url)) {
             errors.rejectValue(CONTRACT_URL_KEY, INVALID_URL_KEY);
             return false;


### PR DESCRIPTION
User can now create a contract pointing to an internal URL, even if the domain
does not end with a IANA-defined top-level domain.

Fix #121: https://github.com/Tanaguru/Tanaguru/issues/121